### PR TITLE
fix/#873 修正進入創作配方頁面未完成創作，回到實驗室配方出現ＦＢ分享提示

### DIFF
--- a/api/controllers/api/labfnp/RecipeController.js
+++ b/api/controllers/api/labfnp/RecipeController.js
@@ -64,6 +64,7 @@ module.exports = {
       }
       sails.log.info('create recipe controller=>', data);
       const recipe = await RecipeService.create(data);
+      req.flash('info', 'Info.New.Recipe');
       res.ok({
         message: 'Create recipe success.',
         data: recipe,

--- a/api/controllers/labfnp/RecipeController.js
+++ b/api/controllers/labfnp/RecipeController.js
@@ -30,8 +30,6 @@ module.exports = {
         recipe.formula.push(formula);
       }
 
-      req.flash('info', 'Info.New.Recipe');
-
       if (from == 'scent') {
         return res.view({ user, recipe, scents });
       }


### PR DESCRIPTION
修正原來使用者點擊建立新配方就會儲存「為新配方」，修正為使用者「送出」建立配方資料後才存儲「為新配方」資訊