### PR TITLE
Fix/#969 

### DIFF
--- a/views-labfnp/labfnp/recipe/feedback.ejs
+++ b/views-labfnp/labfnp/recipe/feedback.ejs
@@ -88,7 +88,7 @@
 
         <h2 class="pull-left">
           <i class="fa fa-comment-o" aria-hidden="true"></i>感覺回饋</h2>
-        <a href="#!" onclick="window.history.back();return false;" class="btn-u btn-u-dark pull-right">返回</a>
+        <a href="/recipe/<%= recipe.hashId %>" class="btn-u btn-u-dark pull-right">返回</a>
 
       </div>
 

--- a/views-labfnp/labfnp/recipe/order.ejs
+++ b/views-labfnp/labfnp/recipe/order.ejs
@@ -78,7 +78,7 @@
 
         <h2 class="pull-left">
           <i class="fa fa-shopping-cart " aria-hidden="true"></i>確認訂單</h2>
-        <a href="#!" onclick="window.history.back();return false;" class="btn-u btn-u-dark pull-right">返回</a>
+        <a href="/recipe/<%= recipe.hashId %>" class="btn-u btn-u-dark pull-right">返回</a>
 
       </div>
 


### PR DESCRIPTION
新增配方後，出現的分享提示，若選擇「暫時不要」，然後再去點選「訂購」or「感覺回饋」

進入「訂購」or「感覺回饋」頁面後又點選「返回」，「分享配方」提示會重複出現

- 修改「返回」按鈕的連結