### PR TITLE
fix/#1067 點選非 menu 區域能將 menu 收起來

### DIFF
--- a/views-labfnp/partials/header.ejs
+++ b/views-labfnp/partials/header.ejs
@@ -102,4 +102,13 @@
       }
     });
   });
+
+
+  $(':not(.navbar-responsive-collapse)').on('click',function(event) {
+    $('.navbar-responsive-collapse').collapse('hide');
+  });
+
+  $(':not(.navbar-responsive-collapse)').on('tap', function(event) {
+    $('.navbar-responsive-collapse').collapse('hide');
+  });
 `); %>


### PR DESCRIPTION
增加反向選擇，非 navbar 的區域被點選時，會關閉 collapse 選單