### PR TITLE
config 維護功能 Spec

### DIFF
--- a/api/controllers/AdminController.js
+++ b/api/controllers/AdminController.js
@@ -38,7 +38,7 @@ module.exports = {
     res.ok({view: true});
   },
 
-  config: function(req, res) {
+  configJson: function(req, res) {
     let config = {
       title: 'CargoCMS 雲端管理系統',
       copyright: '© Laboratory of Fragrance &amp; Perfume',

--- a/api/controllers/admin/ConfigController.js
+++ b/api/controllers/admin/ConfigController.js
@@ -1,0 +1,28 @@
+module.exports = {
+  index: async (req, res) => {
+    res.ok({
+      view: true,
+      serverSidePaging: true,
+      layout: 'admin/default/index'
+    });
+  },
+  create: async (req, res) => {
+    res.ok({
+      view: true,
+      layout: 'admin/default/create'
+    });
+  },
+  edit: async (req, res) => {
+    res.ok({
+      view: true,
+      layout: 'admin/default/edit'
+    });
+
+  },
+  show: async (req, res) => {
+    res.ok({
+      view: true,
+      layout: 'admin/default/show'
+    });
+  },
+}

--- a/api/controllers/api/admin/ConfigController.js
+++ b/api/controllers/api/admin/ConfigController.js
@@ -1,0 +1,77 @@
+module.exports = {
+
+  find: async (req, res) => {
+    try {
+      const { query, method, body } = req;
+      const { serverSidePaging } = query;
+      const modelName = req.options.controller.split("/").reverse()[0];
+      const include = [  ];
+      const isPost = method === 'POST';
+      let mServerSidePaging = isPost ? body.serverSidePaging : serverSidePaging;
+      let mQuery = isPost ? body : query;
+      let result;
+      if (mServerSidePaging) {
+        result = await PagingService.process({ query: mQuery, modelName, include });
+      } else {
+        const items = await sails.models[modelName].findAll({
+          include
+        });
+        result = { data: { items } };
+      }
+      res.ok(result);
+    } catch (e) {
+      res.serverError(e);
+    }
+  },
+
+  findOne: async (req, res) => {
+    try {
+      const { id } = req.params;
+      const item = await Config.findOne({
+        where:{
+          id
+        },
+        include: []
+      });
+      res.ok({data: {item}});
+    } catch (e) {
+      res.serverError(e);
+    }
+  },
+
+  create: async (req, res) => {
+    try {
+      let data = req.body;
+      const item = await Config.create(data);
+      let message = 'Create success.';
+      res.ok({ message, data: { item } } );
+    } catch (e) {
+      res.serverError(e);
+    }
+  },
+
+  update: async (req, res) => {
+    try {
+      const { id } = req.params;
+      const data = req.body;
+      const message = 'Update success.';
+      const item = await Config.update(data ,{
+        where: { id, },
+      });
+      res.ok({ message, data: { item } });
+    } catch (e) {
+      res.serverError(e);
+    }
+  },
+
+  destroy: async (req, res) => {
+    try {
+      const { id } = req.params;
+      const item = await Config.destroy({ where: { id } });
+      let message = 'Delete success';
+      res.ok({message, data: {item}});
+    } catch (e) {
+      res.serverError(e);
+    }
+  }
+}

--- a/api/controllers/api/admin/ConfigController.js
+++ b/api/controllers/api/admin/ConfigController.js
@@ -54,6 +54,7 @@ module.exports = {
     try {
       const { id } = req.params;
       const data = req.body;
+      delete data.deletedAt;
       const message = 'Update success.';
       const item = await Config.update(data ,{
         where: { id, },
@@ -70,6 +71,17 @@ module.exports = {
       const item = await Config.destroy({ where: { id } });
       let message = 'Delete success';
       res.ok({message, data: {item}});
+    } catch (e) {
+      res.serverError(e);
+    }
+  },
+
+  reload: async (req, res) => {
+    try {
+      await ConfigService.sync();
+      await ConfigService.load();
+      const message = 'reload config success';
+      res.ok({message, data: {}});
     } catch (e) {
       res.serverError(e);
     }

--- a/api/models/Config.js
+++ b/api/models/Config.js
@@ -13,7 +13,7 @@ module.exports = {
       // allowNull: false,
     },
     value: {
-      type:  Sequelize.STRING,
+      type:  Sequelize.TEXT,
       allowNull: false,
     },
     type: {

--- a/api/models/Config.js
+++ b/api/models/Config.js
@@ -10,7 +10,7 @@ module.exports = {
     },
     description: {
       type:  Sequelize.STRING,
-      allowNull: false,
+      // allowNull: false,
     },
     value: {
       type:  Sequelize.STRING,

--- a/api/models/config.js
+++ b/api/models/config.js
@@ -1,0 +1,57 @@
+import moment from 'moment';
+
+module.exports = {
+  attributes: {
+    name: {
+      type:  Sequelize.STRING,
+      allowNull: false,
+    },
+    key: {
+      type:  Sequelize.STRING,
+      allowNull: false,
+    },
+    description: {
+      type:  Sequelize.STRING,
+      allowNull: false,
+    },
+    value: {
+      type:  Sequelize.STRING,
+      allowNull: false,
+    },
+    type: {
+      type: Sequelize.ENUM('text', 'editor', 'url', 'file'),
+      defaultValue: 'text',
+      allowNull: false,
+    },
+
+    createdDateTime: {
+      type: Sequelize.VIRTUAL,
+      get: function(){
+        try{
+          return UtilsService.DataTimeFormat(this.getDataValue('createdAt'));
+        } catch(e){
+          sails.log.error(e);
+        }
+      }
+    },
+    updatedDateTime: {
+      type: Sequelize.VIRTUAL,
+      get: function() {
+        try{
+          return UtilsService.DataTimeFormat(this.getDataValue('updatedAt'));
+        } catch(e){
+          sails.log.error(e);
+        }
+      }
+    },
+  },
+  associations: function() {
+
+  },
+  options: {
+    paranoid: true,
+    classMethods: {},
+    instanceMethods: {},
+    hooks: {}
+  }
+};

--- a/api/models/config.js
+++ b/api/models/config.js
@@ -1,5 +1,3 @@
-import moment from 'moment';
-
 module.exports = {
   attributes: {
     name: {
@@ -19,7 +17,7 @@ module.exports = {
       allowNull: false,
     },
     type: {
-      type: Sequelize.ENUM('text', 'editor', 'url', 'file', 'boolean'),
+      type: Sequelize.ENUM('text', 'editor', 'url', 'file', 'boolean', 'array'),
       defaultValue: 'text',
       allowNull: false,
     },

--- a/api/models/config.js
+++ b/api/models/config.js
@@ -19,7 +19,7 @@ module.exports = {
       allowNull: false,
     },
     type: {
-      type: Sequelize.ENUM('text', 'editor', 'url', 'file'),
+      type: Sequelize.ENUM('text', 'editor', 'url', 'file', 'boolean'),
       defaultValue: 'text',
       allowNull: false,
     },

--- a/api/policies/sessionAuth.js
+++ b/api/policies/sessionAuth.js
@@ -8,11 +8,12 @@
  *
  */
 module.exports = async function(req, res, next) {
+  try {
 
   // User is allowed, proceed to the next policy,
   // or if this is the last policy, the controller
   const user = AuthService.getSessionUser(req);
-  console.log("req.session", user);
+  console.log("req.session", user, sails.config.offAuth);
   if (sails.config.offAuth || user) {
     // const noEmail = !user.email;
     // if (noEmail || user.email === '') {
@@ -21,7 +22,7 @@ module.exports = async function(req, res, next) {
     //   return res.redirect('/edit/me');
     // }
 
-    if (sails.config.verificationEmail && user.verificationEmailToken) {
+    if (sails.config.verificationEmail && user && user.verificationEmailToken) {
       const modelUser = await User.findById(user.id);
       if (modelUser.verificationEmailToken) {
         req.flash('info', '請先驗證完您的 Email 才能使用此功能');
@@ -35,4 +36,7 @@ module.exports = async function(req, res, next) {
   // User is not allowed
   // (default res.forbidden() behavior can be overridden in `config/403.js`)
   return res.forbidden('You are not permitted to perform this action.');
+  } catch (e) {
+    sails.log.error(e);
+  }
 };

--- a/api/policies/sessionAuth.js
+++ b/api/policies/sessionAuth.js
@@ -14,7 +14,7 @@ module.exports = async function(req, res, next) {
   // or if this is the last policy, the controller
   const user = AuthService.getSessionUser(req);
   console.log("req.session", user, sails.config.offAuth);
-  if (sails.config.offAuth || user) {
+  if (sails.config.offAuth == true || user) {
     // const noEmail = !user.email;
     // if (noEmail || user.email === '') {
     //   sails.log.warn('使用者登入沒有 Email');

--- a/api/responses/forbidden.js
+++ b/api/responses/forbidden.js
@@ -13,7 +13,6 @@
  */
 
 module.exports = function forbidden (data, options) {
-
   // Get access to `req`, `res`, & `sails`
   var req = this.req;
   var res = this.res;
@@ -64,7 +63,7 @@ module.exports = function forbidden (data, options) {
   else {
     if (req.path.split('/')[1] === 'admin') {
       sails.log.info('Forbidden redirect /admin/login');
-      
+
       return res.redirect('/admin/login');
     } else {
 

--- a/api/services/ConfigService.js
+++ b/api/services/ConfigService.js
@@ -107,13 +107,15 @@ module.exports = {
         if (info.key) {
           let pathArray = info.key.split('.');
           if (pathArray.length > 0) {
-            const value = info.type === 'array' ? JSON.parse(info.value) : info.value
+            const value = info.type === 'array' ? JSON.parse(info.value) : info.value;
             result[name] = ConfigService.arrayTOObject(result[name], pathArray, value);
           } else {
-            result[name] = info.value;
+            const value = info.type === 'boolean' ? !!info.value : info.value;
+            result[name] = value;
           }
         } else {
-          result[name] = info.value;
+          const value = info.type === 'boolean' ? !!info.value : info.value
+          result[name] = value;
         }
       })
       sails.log.info(result);

--- a/api/services/ConfigService.js
+++ b/api/services/ConfigService.js
@@ -3,6 +3,7 @@ module.exports = {
 
   sync: async() => {
     try {
+      sails.log.info('sync model config & local config');
       const devConfig = require('../../config/env/development');
       const prodConfig = require('../../config/env/production');
       const localConfig = require('../../config/local');
@@ -15,7 +16,6 @@ module.exports = {
       );
       const pureJSONConfig = JSON.parse(JSON.stringify(allConfig));
       let formatConfig = ConfigService.jsonTOPath(pureJSONConfig);
-      sails.log.debug(formatConfig, pureJSONConfig);
       for(let data of formatConfig) {
         data = {
           ...data,
@@ -43,6 +43,7 @@ module.exports = {
 
   load: async() => {
     try {
+      sails.log.info('update sails config');
       let modelConfig = await ConfigService.getModelJSONConfig();
       sails.config = _.merge(
         sails.config,

--- a/api/services/ConfigService.js
+++ b/api/services/ConfigService.js
@@ -53,23 +53,20 @@ module.exports = {
       data.forEach((info) => {
         const name = info.name;
         result[name] = result[name] || {};
-        console.log(info);
-        if(info.type === 'array') {
-          result[name] = JSON.parse(info.value);
-        } else {
-          if (info.path) {
-            let pathArray = info.path.split('.');
-            if (pathArray.length > 1) {
-              result[name] = ConfigService.arrayTOObject(result[name], pathArray, info.value);
-            } else {
-              result[name] = info.value;
-            }
+        if (info.path) {
+          let pathArray = info.path.split('.');
+          if (pathArray.length > 0) {
+            const value = info.type === 'array' ? JSON.parse(info.value) : info.value
+            result[name] = ConfigService.arrayTOObject(result[name], pathArray, value);
           } else {
             result[name] = info.value;
           }
+        } else {
+          result[name] = info.value;
         }
       })
-      sails.log.info("info!!!!!!!!", result);
+      sails.log.info(result);
+      return result;
     } catch (e) {
       throw e;
     }
@@ -110,19 +107,14 @@ module.exports = {
     }
   },
 
-  arrayTOObject: (target, array, value) => {
+  arrayTOObject: (obj, keys, value) => {
     try {
-      console.log("!!!!!!!", target, array, value);
-      // let result = {};
-      array.forEach((data, index) => {
-        if (index === array.length -1) {
-          target[data] = value;
-        } else {
-          target[data] = target[data] || {}
-        }
-      });
-      sails.log.debug(target);
-      return target
+      const lastKey = keys.pop();
+      const lastObj = keys.reduce((obj, key) =>
+          obj[key] = obj[key] || {},
+          obj);
+      lastObj[lastKey] = value;
+      return obj;
     } catch (e) {
       throw e;
     }

--- a/api/services/ConfigService.js
+++ b/api/services/ConfigService.js
@@ -4,13 +4,18 @@ module.exports = {
   sync: async() => {
     try {
       sails.log.info('sync model config & local config');
-      const devConfig = require('../../config/env/development');
-      const prodConfig = require('../../config/env/production');
+      let envCnfig = {};
+      if (sails.config.environment === 'production') {
+         envCnfig = require('../../config/env/production');
+      } else if (sails.config.environment === 'development') {
+        envCnfig = require('../../config/env/development');
+      } else {
+        envCnfig = require('../../config/env/test');
+      }
       const localConfig = require('../../config/local');
       let modelAllConfig = await ConfigService.getModelJSONConfig();
       const allConfig = _.merge(
-        devConfig,
-        prodConfig,
+        envCnfig,
         localConfig,
         modelAllConfig
       );

--- a/api/services/ConfigService.js
+++ b/api/services/ConfigService.js
@@ -1,0 +1,15 @@
+module.exports = {
+
+  sync: function() {
+
+  },
+
+  load: function() {
+
+  },
+
+  init: function() {
+
+  }
+
+}

--- a/api/services/ConfigService.js
+++ b/api/services/ConfigService.js
@@ -1,15 +1,131 @@
+import _ from 'lodash';
 module.exports = {
 
-  sync: function() {
+  sync: () => {
 
   },
 
-  load: function() {
+  load: () => {
 
   },
 
-  init: function() {
+  init: () => {
 
+  },
+
+  jsonTOPath: (data) => {
+    try {
+      sails.log.debug(data);
+      let result = [];
+      for (const key of Object.keys(data)) {
+        if(_.isArray(data[key])){
+          result.push({
+            name: key,
+            value: JSON.stringify(data[key]),
+            type: 'array'
+          });
+        } else if (_.isObject(data[key])) {
+          let formatObject = ConfigService.getPath(data[key], '', []);
+          formatObject = formatObject.map((data) => {
+            return {
+              name: key,
+              ...data,
+            }
+          });
+          result = result.concat(formatObject);
+        } else {
+          result.push({
+            name: key,
+            value: data[key],
+            type: 'text'
+          });
+        }
+      }
+      return result;
+    } catch (e) {
+      throw e;
+    }
+  },
+
+  pathTOJSON: (data) => {
+    try {
+      const result = {};
+      data.forEach((info) => {
+        const name = info.name;
+        result[name] = result[name] || {};
+        console.log(info);
+        if(info.type === 'array') {
+          result[name] = JSON.parse(info.value);
+        } else {
+          if (info.path) {
+            let pathArray = info.path.split('.');
+            if (pathArray.length > 1) {
+              result[name] = ConfigService.arrayTOObject(result[name], pathArray, info.value);
+            } else {
+              result[name] = info.value;
+            }
+          } else {
+            result[name] = info.value;
+          }
+        }
+      })
+      sails.log.info("info!!!!!!!!", result);
+    } catch (e) {
+      throw e;
+    }
+  },
+
+
+  getPath: (data, path, result) => {
+    try {
+      if(_.isEmpty(data)) {
+        return result;
+      } else {
+        for (const key of Object.keys(data)) {
+          if(_.isArray(data[key])){
+            const value = data[key];
+            result.push({
+              path: `${path}${path ? '.': ''}${key}`,
+              value: JSON.stringify(value),
+              type: 'array'
+            });
+            delete data[key];
+            return ConfigService.getPath(data, path, result);
+          } else if (_.isObject(data[key])) {
+            return ConfigService.getPath(data[key], `${path}${path ? '.': ''}${key}`, result)
+          } else {
+            const value = data[key];
+            result.push({
+              path: `${path}${path ? '.': ''}${key}`,
+              value,
+              type: 'text'
+            });
+            delete data[key];
+            return ConfigService.getPath(data, path, result);
+          }
+        }
+      }
+    } catch (e) {
+      throw e;
+    }
+  },
+
+  arrayTOObject: (target, array, value) => {
+    try {
+      console.log("!!!!!!!", target, array, value);
+      // let result = {};
+      array.forEach((data, index) => {
+        if (index === array.length -1) {
+          target[data] = value;
+        } else {
+          target[data] = target[data] || {}
+        }
+      });
+      sails.log.debug(target);
+      return target
+    } catch (e) {
+      throw e;
+    }
   }
 
 }

--- a/config/bootstrap.js
+++ b/config/bootstrap.js
@@ -174,6 +174,9 @@ module.exports.bootstrap = async (cb) => {
       sails.log.error('Facebook Page ID or App ID not exist!!');
     }
 
+    await ConfigService.sync();
+    await ConfigService.load();
+
     cb();
   } catch (e) {
     sails.log.error(e.stack);

--- a/config/bootstrap.js
+++ b/config/bootstrap.js
@@ -86,6 +86,44 @@ module.exports.bootstrap = async (cb) => {
      * 是否要匯入的判斷必須交給 init 定義的程式負責
      */
 
+    let config = [
+
+      {name: 'mail', path: "orderConfirm.sendBy", value: "", description: ""},
+      {name: 'mail', path: "orderConfirm.subject", value: "", description: ""},
+      {name: 'mail', path: "orderConfirm.html", value: "", description: ""},
+
+      {name: 'reCAPTCHA', path: "key", value: "", description: ""},
+      {name: 'reCAPTCHA', path: "secret", value: "", description: ""},
+
+      {name: 'facebook', path: "accessToken", value: "", description: ""},
+      {name: 'facebook', path: "pageId", value: "", description: ""},
+
+      {name: 'google', path: "analytics.accountid", value: "", description: ""},
+      {name: 'google', path: "analytics.send", value: "", description: ""},
+
+      {name: 'website', path: "store.name", value: "", description: ""},
+      {name: 'website', path: "admin.login.title", value: "", description: ""},
+      {name: 'website', path: "admin.login.footer", value: "", description: ""},
+      {name: 'website', path: "admin.dashboard.title", value: "", description: ""},
+      {name: 'website', path: "admin.dashboard.footer", value: "", description: ""},
+      {name: 'website', path: "admin.dashboard.logo", value: "", type: "file", description: ""},
+
+      {name: 'website', path: "title", value: "", description: ""},
+      {name: 'website', path: "meta.author", value: "", description: ""},
+      {name: 'website', path: "meta.description", value: "", description: ""},
+      {name: 'website', path: "meta.og.site_name", value: "", description: ""},
+      {name: 'website', path: "meta.og.locale", value: "", description: ""},
+      {name: 'website', path: "meta.og.image", value: "", type: "file", description: ""},
+      {name: 'website', path: "meta.og.image.type", value: "", description: ""},
+      {name: 'website', path: "meta.og.image.width", value: "", description: ""},
+      {name: 'website', path: "meta.og.image.height", value: "", description: ""},
+      {name: 'website', path: "meta.og.title", value: "", description: ""},
+      {name: 'website', path: "meta.og.description", value: "", description: ""},
+      {name: 'website', path: "meta.og.type", value: "", description: ""},
+      {name: 'website', path: "favicon", value: "", type: "file", description: ""}
+
+    ]
+
     if (environment !== 'test') {
       // 自動掃描 init 底下的 module 資料夾後執行資料初始化
       fs.readdir('./config/init/', async function(err, files) {

--- a/config/bootstrap.js
+++ b/config/bootstrap.js
@@ -96,11 +96,13 @@ module.exports.bootstrap = async (cb) => {
       {name: 'mail', path: "contact.confirm.subject", value: "", description: ""},
       {name: 'mail', path: "contact.confirm.html", value: "", description: ""},
       {name: 'mail', path: "contact.confirm.to", value: "", description: ""},
+      {name: 'mail', path: "contact.confirm.sendMail", value: "", type: "boolean", description: ""},
 
       {name: 'mail', path: "contact.sendToAdmin.sendBy", value: "", description: ""},
       {name: 'mail', path: "contact.sendToAdmin.subject", value: "", description: ""},
       {name: 'mail', path: "contact.sendToAdmin.html", value: "", description: ""},
       {name: 'mail', path: "contact.sendToAdmin.to", value: "", description: ""},
+      {name: 'mail', path: "contact.sendToAdmin.sendMail", value: "", type: "boolean", description: ""},
 
 
       {name: 'reCAPTCHA', path: "key", value: "", description: ""},

--- a/config/bootstrap.js
+++ b/config/bootstrap.js
@@ -92,15 +92,16 @@ module.exports.bootstrap = async (cb) => {
       {name: 'mail', path: "orderConfirm.subject", value: "", description: ""},
       {name: 'mail', path: "orderConfirm.html", value: "", type: "editor", description: ""},
 
-      {name: 'mail', path: "contact.Confirm.sendBy", value: "", description: ""},
-      {name: 'mail', path: "contact.Confirm.subject", value: "", description: ""},
-      {name: 'mail', path: "contact.Confirm.html", value: "", description: ""},
-      {name: 'mail', path: "contact.Confirm.to", value: "", description: ""},
+      {name: 'mail', path: "contact.confirm.sendBy", value: "", description: ""},
+      {name: 'mail', path: "contact.confirm.subject", value: "", description: ""},
+      {name: 'mail', path: "contact.confirm.html", value: "", description: ""},
+      {name: 'mail', path: "contact.confirm.to", value: "", description: ""},
 
-      {name: 'mail', path: "contact.SendToAdmin.sendBy", value: "", description: ""},
-      {name: 'mail', path: "contact.SendToAdmin.subject", value: "", description: ""},
-      {name: 'mail', path: "contact.SendToAdmin.html", value: "", description: ""},
-      {name: 'mail', path: "contact.SendToAdmin.to", value: "", description: ""},
+      {name: 'mail', path: "contact.sendToAdmin.sendBy", value: "", description: ""},
+      {name: 'mail', path: "contact.sendToAdmin.subject", value: "", description: ""},
+      {name: 'mail', path: "contact.sendToAdmin.html", value: "", description: ""},
+      {name: 'mail', path: "contact.sendToAdmin.to", value: "", description: ""},
+
 
       {name: 'reCAPTCHA', path: "key", value: "", description: ""},
       {name: 'reCAPTCHA', path: "secret", value: "", description: ""},

--- a/config/bootstrap.js
+++ b/config/bootstrap.js
@@ -90,7 +90,17 @@ module.exports.bootstrap = async (cb) => {
 
       {name: 'mail', path: "orderConfirm.sendBy", value: "", description: ""},
       {name: 'mail', path: "orderConfirm.subject", value: "", description: ""},
-      {name: 'mail', path: "orderConfirm.html", value: "", description: ""},
+      {name: 'mail', path: "orderConfirm.html", value: "", type: "editor", description: ""},
+
+      {name: 'mail', path: "contact.Confirm.sendBy", value: "", description: ""},
+      {name: 'mail', path: "contact.Confirm.subject", value: "", description: ""},
+      {name: 'mail', path: "contact.Confirm.html", value: "", description: ""},
+      {name: 'mail', path: "contact.Confirm.to", value: "", description: ""},
+
+      {name: 'mail', path: "contact.SendToAdmin.sendBy", value: "", description: ""},
+      {name: 'mail', path: "contact.SendToAdmin.subject", value: "", description: ""},
+      {name: 'mail', path: "contact.SendToAdmin.html", value: "", description: ""},
+      {name: 'mail', path: "contact.SendToAdmin.to", value: "", description: ""},
 
       {name: 'reCAPTCHA', path: "key", value: "", description: ""},
       {name: 'reCAPTCHA', path: "secret", value: "", description: ""},

--- a/config/init/labfnp/index.js
+++ b/config/init/labfnp/index.js
@@ -49,6 +49,8 @@ module.exports.init = async () => {
       { href: '/admin/suppliershiporder', title: '供應商出貨訂單', sequence: 30, ParentMenuItemId: 6},
       { href: '/admin/suppliershiporderdescription', title: '供應商詳細出貨訂單', sequence: 40, ParentMenuItemId: 6},
 
+
+      { icon: 'sliders', href: '/admin/config', title: '設定', sequence: 160},
     ]
 
     let title = newMenuItems.map(item => item.title)

--- a/config/policies.js
+++ b/config/policies.js
@@ -85,6 +85,9 @@ var defaultConfig = {
   "api/admin/UserController": {
     '*': ['passport', 'sessionAuth', 'isAdmin'],
   },
+  "api/admin/ConfigController": {
+    '*': ['passport', 'sessionAuth', 'isAdmin'],
+  },
   "api/admin/ProductController": {
     '*': ['passport', 'sessionAuth', 'isAdmin'],
   },

--- a/config/routes.js
+++ b/config/routes.js
@@ -48,6 +48,7 @@ var defaultConfig = {
   'post /api/admin/config': 'api/admin/ConfigController.create',
   'put /api/admin/config/:id': 'api/admin/ConfigController.update',
   'delete /api/admin/config/:id': 'api/admin/ConfigController.destroy',
+  'post /api/admin/config/reload': 'api/admin/ConfigController.reload',
 
   'get /api/admin/quote': 'api/admin/QuoteController.find',
   'get /api/admin/quote/:id': 'api/admin/QuoteController.findOne',
@@ -177,7 +178,7 @@ var defaultConfig = {
 
   //----- Admin -----
   '/admin':           'AdminController.index',
-  '/admin/config.js': 'AdminController.config',
+  '/admin/config.js': 'AdminController.configJson',
 
   //----- AuthController -----
   'get /login': 'AuthController.login',

--- a/config/routes.js
+++ b/config/routes.js
@@ -43,6 +43,11 @@ var defaultConfig = {
   'put /api/admin/post/:id': 'api/admin/PostController.update',
   'delete /api/admin/post/:id': 'api/admin/PostController.destroy',
 
+  'get /api/admin/config': 'api/admin/ConfigController.find',
+  'get /api/admin/config/:id': 'api/admin/ConfigController.findOne',
+  'post /api/admin/config': 'api/admin/ConfigController.create',
+  'put /api/admin/config/:id': 'api/admin/ConfigController.update',
+  'delete /api/admin/config/:id': 'api/admin/ConfigController.destroy',
 
   'get /api/admin/quote': 'api/admin/QuoteController.find',
   'get /api/admin/quote/:id': 'api/admin/QuoteController.findOne',

--- a/test/unit/services/ConfigService.spec.js
+++ b/test/unit/services/ConfigService.spec.js
@@ -11,7 +11,7 @@ describe.skip('about Config Service operation.', function() {
 
   });
 
-  it('config model 更新後，重新載入 sails.fonfig', async (done) => {
+  it('config model 更新後，重新載入 sails.config', async (done) => {
 
     try {
       let result = ConfigService.load();
@@ -26,7 +26,7 @@ describe.skip('about Config Service operation.', function() {
   it('相關 service 重新初始，如：email, passport', async (done) => {
 
     try {
-      let result = ConfigService.init();
+      let result = ConfigService.initService();
       result.should.be.true;
       done();
     } catch (e) {

--- a/test/unit/services/ConfigService.spec.js
+++ b/test/unit/services/ConfigService.spec.js
@@ -1,4 +1,91 @@
-describe.skip('about Config Service operation.', function() {
+describe('about Config Service operation.', function() {
+
+  it('json 轉 model path', (done) => {
+    try {
+      const data = {
+        bool: true,
+        text: '123',
+        array: [1, 2, 3],
+        reCAPTCHA: {
+          key: 'keykeykeykeykeykeykey',
+          secret: 'secretsecretsecretsecretsecret',
+        },
+        passport: {
+          facebook: {
+            name: 'Facebook',
+            protocol: 'oauth2',
+            options: {
+              clientID: 'testtesttesttesttesttest',
+              clientSecret: 'testtesttesttesttesttest',
+              callbackURL: "http://localhost:5001/auth/facebook/callback",
+              scope: [ 'email', 'public_profile' ],
+              profileFields: [
+                'id', 'email', 'gender', 'link', 'locale',
+                'name', 'timezone', 'updated_time', 'verified',
+                'displayName', 'photos'
+              ]
+            }
+          }
+        }
+      }
+      const result = ConfigService.jsonTOPath(data);
+      console.log(result);
+      done();
+    } catch (e) {
+      done(e);
+    }
+  });
+
+
+  it.only('model path 轉 json', (done) => {
+    try {
+      const data = [ { name: 'bool', value: true, type: 'text' },
+      { name: 'text', value: '123', type: 'text' },
+      { name: 'array', value: '[1,2,3]', type: 'array' },
+      { name: 'reCAPTCHA',
+        path: 'key',
+        value: 'keykeykeykeykeykeykey',
+        type: 'text' },
+      { name: 'reCAPTCHA',
+        path: 'secret',
+        value: 'secretsecretsecretsecretsecret',
+        type: 'text' },
+      { name: 'passport',
+        path: 'facebook.name',
+        value: 'Facebook',
+        type: 'text' },
+      { name: 'passport',
+        path: 'facebook.protocol',
+        value: 'oauth2',
+        type: 'text' },
+      { name: 'passport',
+        path: 'facebook.options.clientID',
+        value: 'testtesttesttesttesttest',
+        type: 'text' },
+      { name: 'passport',
+        path: 'facebook.options.clientSecret',
+        value: 'testtesttesttesttesttest',
+        type: 'text' },
+      { name: 'passport',
+        path: 'facebook.options.callbackURL',
+        value: 'http://localhost:5001/auth/facebook/callback',
+        type: 'text' },
+      { name: 'passport',
+        path: 'facebook.options.scope',
+        value: '["email","public_profile"]',
+        type: 'array' },
+      { name: 'passport',
+        path: 'facebook.options.profileFields',
+        value: '["id","email","gender","link","locale","name","timezone","updated_time","verified","displayName","photos"]',
+        type: 'array' } ]
+      const result = ConfigService.pathTOJSON(data);
+      console.log(result);
+      done();
+    } catch (e) {
+      done(e);
+    }
+  });
+
   it('將 sails.config 同步至 config model', async (done) => {
 
     try {

--- a/test/unit/services/ConfigService.spec.js
+++ b/test/unit/services/ConfigService.spec.js
@@ -1,0 +1,38 @@
+describe.skip('about Config Service operation.', function() {
+  it('將 sails.config 同步至 config model', async (done) => {
+
+    try {
+      let result = ConfigService.sync();
+      result.should.be.true;
+      done();
+    } catch (e) {
+      done(e);
+    }
+
+  });
+
+  it('config model 更新後，重新載入 sails.fonfig', async (done) => {
+
+    try {
+      let result = ConfigService.load();
+      result.should.be.true;
+      done();
+    } catch (e) {
+      done(e);
+    }
+
+  });
+
+  it('相關 service 重新初始，如：email, passport', async (done) => {
+
+    try {
+      let result = ConfigService.init();
+      result.should.be.true;
+      done();
+    } catch (e) {
+      done(e);
+    }
+
+  });
+
+});

--- a/test/unit/services/ConfigService.spec.js
+++ b/test/unit/services/ConfigService.spec.js
@@ -1,5 +1,23 @@
 describe('about Config Service operation.', function() {
 
+  before('測試用 config', async(done) => {
+    try {
+      await Config.create({
+        name: 'appUrl',
+        key: '',
+        value: 'http://localhost:1338',
+      });
+      await Config.create({
+        name: 'test',
+        key: 'key1',
+        value: 'value1',
+      });
+      done();
+    } catch (e) {
+      done(e);
+    }
+  })
+
   it('json 轉 model path', (done) => {
     try {
       const data = {
@@ -36,46 +54,45 @@ describe('about Config Service operation.', function() {
     }
   });
 
-
-  it.only('model path 轉 json', (done) => {
+  it('model path 轉 json', (done) => {
     try {
       const data = [ { name: 'bool', value: true, type: 'text' },
       { name: 'text', value: '123', type: 'text' },
       { name: 'array', value: '[1,2,3]', type: 'array' },
       { name: 'reCAPTCHA',
-        path: 'key',
+        key: 'key',
         value: 'keykeykeykeykeykeykey',
         type: 'text' },
       { name: 'reCAPTCHA',
-        path: 'secret',
+        key: 'secret',
         value: 'secretsecretsecretsecretsecret',
         type: 'text' },
       { name: 'passport',
-        path: 'facebook.name',
+        key: 'facebook.name',
         value: 'Facebook',
         type: 'text' },
       { name: 'passport',
-        path: 'facebook.protocol',
+        key: 'facebook.protocol',
         value: 'oauth2',
         type: 'text' },
       { name: 'passport',
-        path: 'facebook.options.clientID',
+        key: 'facebook.options.clientID',
         value: 'testtesttesttesttesttest',
         type: 'text' },
       { name: 'passport',
-        path: 'facebook.options.clientSecret',
+        key: 'facebook.options.clientSecret',
         value: 'testtesttesttesttesttest',
         type: 'text' },
       { name: 'passport',
-        path: 'facebook.options.callbackURL',
+        key: 'facebook.options.callbackURL',
         value: 'http://localhost:5001/auth/facebook/callback',
         type: 'text' },
       { name: 'passport',
-        path: 'facebook.options.scope',
+        key: 'facebook.options.scope',
         value: '["email","public_profile"]',
         type: 'array' },
       { name: 'passport',
-        path: 'facebook.options.profileFields',
+        key: 'facebook.options.profileFields',
         value: '["id","email","gender","link","locale","name","timezone","updated_time","verified","displayName","photos"]',
         type: 'array' } ]
       const result = ConfigService.pathTOJSON(data);
@@ -89,7 +106,7 @@ describe('about Config Service operation.', function() {
   it('將 sails.config 同步至 config model', async (done) => {
 
     try {
-      let result = ConfigService.sync();
+      let result = await ConfigService.sync();
       result.should.be.true;
       done();
     } catch (e) {
@@ -98,10 +115,10 @@ describe('about Config Service operation.', function() {
 
   });
 
-  it('config model 更新後或是 bootstrap 時，載入 sails.config', async (done) => {
+  it.only('config model 更新後或是 bootstrap 時，載入 sails.config', async (done) => {
 
     try {
-      let result = ConfigService.load();
+      let result = await ConfigService.load();
       result.should.be.true;
       done();
     } catch (e) {

--- a/test/unit/services/ConfigService.spec.js
+++ b/test/unit/services/ConfigService.spec.js
@@ -11,7 +11,7 @@ describe.skip('about Config Service operation.', function() {
 
   });
 
-  it('config model 更新後，重新載入 sails.config', async (done) => {
+  it('config model 更新後或是 bootstrap 時，載入 sails.config', async (done) => {
 
     try {
       let result = ConfigService.load();

--- a/test/unit/services/ConfigService.spec.js
+++ b/test/unit/services/ConfigService.spec.js
@@ -7,10 +7,11 @@ describe('about Config Service operation.', function() {
         key: '',
         value: 'http://localhost:1338',
       });
-      await Config.create({
+      let a = await Config.create({
         name: 'test',
         key: 'key1',
-        value: 'value1',
+        value: true,
+        type: 'boolean',
       });
       done();
     } catch (e) {
@@ -56,7 +57,7 @@ describe('about Config Service operation.', function() {
 
   it('model path 轉 json', (done) => {
     try {
-      const data = [ { name: 'bool', value: true, type: 'text' },
+      const data = [ { name: 'bool', value: true, type: 'boolean' },
       { name: 'text', value: '123', type: 'text' },
       { name: 'array', value: '[1,2,3]', type: 'array' },
       { name: 'reCAPTCHA',
@@ -115,7 +116,7 @@ describe('about Config Service operation.', function() {
 
   });
 
-  it.only('config model 更新後或是 bootstrap 時，載入 sails.config', async (done) => {
+  it('config model 更新後或是 bootstrap 時，載入 sails.config', async (done) => {
 
     try {
       let result = await ConfigService.load();

--- a/views-labfnp/admin/config/create.ejs
+++ b/views-labfnp/admin/config/create.ejs
@@ -1,0 +1,16 @@
+<%- include form.ejs %>
+
+<!-- SCRIPTS ON PAGE EVENT -->
+<script type="text/javascript">
+
+	var pagefunction = function() {
+
+		<%- include vue.ejs %>
+		appMain.$mount("#main-create");
+		appMain.setupForm("create");
+		appMain.onEnterPageEdit();
+    appMain.createHide();
+    appMain.editDisabled();
+
+	};
+</script>

--- a/views-labfnp/admin/config/edit.ejs
+++ b/views-labfnp/admin/config/edit.ejs
@@ -1,0 +1,18 @@
+
+<%- include form.ejs %>
+
+<!-- SCRIPTS ON PAGE EVENT -->
+<script type="text/javascript">
+
+
+	var pagefunction = function() {
+		<%- include vue.ejs %>
+		appMain.$mount("#main-edit");
+		appMain.loadItem(function() {
+      appMain.onEnterPageEdit();
+      appMain.editDisabled();
+    });
+		appMain.setupForm("edit");
+	};
+
+</script>

--- a/views-labfnp/admin/config/form.ejs
+++ b/views-labfnp/admin/config/form.ejs
@@ -1,0 +1,77 @@
+<fieldset>
+
+  
+    <section row="">
+      <label class="label">分類</label>
+      <label class="input state-disabled ">
+      <input type="text" name="name" placeholder="" v-model="data.item.name" disabled>
+      <b class="tooltip tooltip-bottom-right">請輸入分類</b></label>
+    </section>
+  
+    <section row="">
+      <label class="label">小分類</label>
+      <label class="input state-disabled ">
+      <input type="text" name="key" placeholder="" v-model="data.item.key" disabled>
+      <b class="tooltip tooltip-bottom-right">請輸入小分類</b></label>
+    </section>
+  
+    <section row="">
+      <label class="label">描述</label>
+      <label class="input state-disabled ">
+      <input type="text" name="description" placeholder="" v-model="data.item.description" disabled>
+      <b class="tooltip tooltip-bottom-right">請輸入描述</b></label>
+    </section>
+  
+    <section row="">
+      <label class="label">數值</label>
+      <label class="input state-disabled ">
+      <input type="text" name="value" placeholder="" v-model="data.item.value" disabled>
+      <b class="tooltip tooltip-bottom-right">請輸入數值</b></label>
+    </section>
+  
+    <section row="">
+      <label class="label">類型</label>
+      <label class="input state-disabled ">
+      <input type="text" name="type" placeholder="" v-model="data.item.type" disabled>
+      <b class="tooltip tooltip-bottom-right">請輸入類型</b></label>
+    </section>
+  
+
+</fieldset>
+<script>
+  var formRules = {
+    name:{
+      required: true,
+    },
+    key:{
+      required: true,
+    },
+    description:{
+      required: true,
+    },
+    value:{
+      required: true,
+    },
+    type:{
+      required: true,
+    },
+  };
+
+  var formMessages = {
+    name:{
+      required: "請給予 分類",
+    },
+    key:{
+      required: "請給予 小分類",
+    },
+    description:{
+      required: "請給予 描述",
+    },
+    value:{
+      required: "請給予 數值",
+    },
+    type:{
+      required: "請給予 類型",
+    },
+  };
+</script>

--- a/views-labfnp/admin/config/index.ejs
+++ b/views-labfnp/admin/config/index.ejs
@@ -1,0 +1,134 @@
+
+<!-- client -->
+<table id="main-table" class="table table-striped table-bordered table-hover" width="100%">
+  <thead>
+    <tr>
+      
+        
+        <th data-hide="phone,tablet"
+        data-class="" class="no-sort">
+          分類
+        </th>
+      
+        
+        <th data-hide=""
+        data-class="" class="no-sort">
+          小分類
+        </th>
+      
+        
+        <th data-hide=""
+        data-class="" class="no-sort">
+          描述
+        </th>
+      
+        
+        <th data-hide=""
+        data-class="" class="no-sort">
+          數值
+        </th>
+      
+        
+        <th data-hide=""
+        data-class="" class="no-sort">
+          類型
+        </th>
+      
+      <th width="80" data-hide="phone,tablet"></th>
+    </tr>
+  </thead>
+  <!-- client only -->
+  <tbody>
+    <tr v-for="item in data.items">
+      
+        <td>{{ item.name}}</td>
+      
+        <td>{{ item.key}}</td>
+      
+        <td>{{ item.description}}</td>
+      
+        <td>{{ item.value}}</td>
+      
+        <td>{{ item.type}}</td>
+      
+      <td align="center" style="cursor: pointer;">
+        <div class="row">
+          <a class="btn btn-default btn-xs" role="button" v-on:click="show(item.id)">
+            <i class="fa-fw fa fa-eye text-muted" />
+          </a>
+          <a class="btn btn-default btn-xs" role="button" v-on:click="edit(item.id)">
+            <i class="fa-fw fa fa-pencil-square-o text-muted"/>
+          </a>
+        </div>
+      </td>
+    </tr>
+  </tbody>
+ </table>
+
+
+<script type="text/javascript">
+  var pagefunction = function() {
+
+    // server only
+    var columns = [
+      
+        
+          { "data": "name" },
+        
+      
+        
+          { "data": "key" },
+        
+      
+        
+          { "data": "description" },
+        
+      
+        
+          { "data": "value" },
+        
+      
+        
+          { "data": "type" },
+        
+      
+        { "data": null },
+    ]
+
+    // server only
+    var columnDefs = [
+      
+        
+      
+        
+      
+        
+      
+        
+      
+        
+      
+      {
+        "targets"  : 5,
+        "orderable": false,
+        "searchable": false,
+        "render": function ( data, type, row ) {
+          var colBody =
+          '<div class="row-action-buttons hidden-xs hidden-sm">'+
+          '<a name="showDataButton" class="btn btn-default btn-xs" role="button" data-id="'+row.id+'">'+
+          '<i class="fa-fw fa fa-eye text-muted" />'+
+          '</a>'+
+          '<a name="editDataButton" class="btn btn-default btn-xs" role="button" data-id="'+row.id+'">'+
+          '<i class="fa-fw fa fa-pencil-square-o text-muted"/>'+
+          '</a>'+
+          '</div>';
+          return colBody;
+        }
+      },
+    ]
+    var serverSidePaging = <%= (data.serverSidePaging != null)?data.serverSidePaging:false %>;
+    <%- include vue.ejs %>
+    appMain.$mount("#main-index");
+    appMain.loadItems(appMain.renderTable);
+  };
+</script>

--- a/views-labfnp/admin/config/show.ejs
+++ b/views-labfnp/admin/config/show.ejs
@@ -1,0 +1,14 @@
+
+<%- include form.ejs %>
+
+<!-- SCRIPTS ON PAGE EVENT -->
+<script type="text/javascript">
+
+	var pagefunction = function() {
+		<%- include vue.ejs %>
+
+		appMain.$mount("#main-edit");
+		appMain.loadItem();
+	};
+
+</script>

--- a/views-labfnp/admin/config/vue.ejs
+++ b/views-labfnp/admin/config/vue.ejs
@@ -17,7 +17,7 @@ var appModel = {
       description: '',
       value: '',
       type: '',
-      
+
     },
     items: [],
     option: {}
@@ -42,4 +42,38 @@ appMain.editDisabled = function(){
 
 appMain.createHide = function () {
   $('.fn-create-hide').hide();
+};
+
+appMain.DataTableInitComplete = function()  {
+  var reloadConfigBtn = '<a class="DTTT_button DTTT_button_text" id="ToolTables_main-table_custom_1" title="重新載入 Config" tabindex="0" aria-controls="main-table"><span>重新載入 Config</span></a>'
+  $(reloadConfigBtn).prependTo('.DTTT_container');
+  $('#ToolTables_main-table_custom_1').on('click', function() {
+    $.SmartMessageBox({
+      title : "重新載入 Config",
+      buttons : "[取消][確定]"
+    }, function(ButtonPress) {
+      if(ButtonPress === '確定') {
+        $.ajax({
+          url: '/api/admin/config/reload',
+          type: 'POST',
+          success: function(result) {
+            console.log(result);
+            messageApp.show({
+              desc: '更新 Config 成功！',
+              type: 'success'
+            });
+            defaultTable.api().ajax.reload(null, false);
+          },
+          error: function(result) {
+            console.log('更新失敗', result);
+            messageApp.show({
+              desc: '更新 Config 失敗！'+ result.responseJSON.message,
+              type: 'error'
+            });
+          },
+        });
+      }
+    });
+  });
+  $('.loading-wrapper').removeClass('active');
 };

--- a/views-labfnp/admin/config/vue.ejs
+++ b/views-labfnp/admin/config/vue.ejs
@@ -1,0 +1,45 @@
+var COMMON = {
+  DOUBLE_CLICK_TIME_PERIOD: 250,
+  DEFAULT_INDEX: -1,
+  DEFAULT_AVATAR: "/assets/admin/img/avatars/default.png",
+};
+
+var itemBeforeEdit = {};
+var prefix = 'admin/';
+var modelName = "config";
+var appModel = {
+  modelName: modelName,
+  prefix: prefix,
+  data: {
+    item: {
+      name: '',
+      key: '',
+      description: '',
+      value: '',
+      type: '',
+      
+    },
+    items: [],
+    option: {}
+  },
+  view: {
+    table: {
+      selectIndex: COMMON.DEFAULT_INDEX,
+    },
+  }
+}
+
+/* TABLETOOLS */
+
+<%- include ../default/vue.ejs %>
+// 需要新增函式可以對 appMain 進行定義，如：
+// appMain.log = function () {console.log("123")}
+
+appMain.editDisabled = function(){
+  $('label.fn-edit-disabled > input').attr('disabled', true);
+  $('label.fn-edit-disabled').addClass('state-disabled');
+};
+
+appMain.createHide = function () {
+  $('.fn-create-hide').hide();
+};


### PR DESCRIPTION
* config/local.js 結構上與 config model 須保持一致
* config model 設置內容將優先於 config/local.js

## bootstrap 處理

檢查 config model 若沒有值，將 sails.config 寫入 config model
使用 `ConfigService.sync()`

1. sails.configbase.local `clone`(不是直接 ref) sails.conifg
2. sails.configbase.model load config model data
3. sails.config 混合 sails.configbase.model 及 sails.configbase.local

上述使用 `ConfigService.load()` 實作方便進行 test

## 第一階段

* 設定檔維護畫面
* 網頁相關設置
* mail templete 設置
* 不需重新初始相關設置

## 第二階段

* passport 相關設置與初始
* mail server 相關設置與初始
* db 相關設置與初始

使用 `ConfigService.initService()`

## 第三階段

設定結果確認

1. fb 粉絲專頁確認
2. google ga 設置後相關資訊確認
3. mail 寄送設置確認
4. fb app id login 確認
5. seo 結果資訊確認
6. fb 貼文資訊確認