### PR TITLE
刪除從後台送來的deletedAt屬性

### DIFF
--- a/api/controllers/api/admin/OrderController.js
+++ b/api/controllers/api/admin/OrderController.js
@@ -117,7 +117,7 @@ module.exports = {
       data.acceptLanguage = '';
 
       // prevent user send deletedAt and make order removed
-      delete data.deletedAt
+      delete data.deletedAt;
       
       const message = 'Update success.';
       const item = await Order.update(data ,{

--- a/api/controllers/api/admin/OrderController.js
+++ b/api/controllers/api/admin/OrderController.js
@@ -116,6 +116,9 @@ module.exports = {
       // data.userAgent = '';
       data.acceptLanguage = '';
 
+      // prevent user send deletedAt and make order removed
+      delete data.deletedAt
+      
       const message = 'Update success.';
       const item = await Order.update(data ,{
         where: { id, },


### PR DESCRIPTION
後台的編輯訂單會送空的deletedAt屬性
但是後端不吃空的date
所以在controller把body.deletedAt移除
也防止使用者硬送deletedAt來刪除不該刪除的訂單

![image](https://cloud.githubusercontent.com/assets/6974496/25796416/02c2b066-340c-11e7-8ccb-4069af752768.png)
