### PR TITLE
fix 首頁商品名稱與資訊太遠 & mobile中產品間距過近

### DIFF
--- a/views-b2b/index.ejs
+++ b/views-b2b/index.ejs
@@ -57,7 +57,7 @@
             <div class="product-img" style="background-image: url('<%= data.items[p].image%>');"></div>
             <h1 class="product-name" title="<%= data.items[p].model %>" data-toggle="tooltip" data-placement="bottom"><%= data.items[p].model %></h1>
           </a>
-          <span class="promotion-label">限量優惠</span>
+          <!--<span class="promotion-label">限量優惠</span>-->
           <p class="product-price">
             <i class="fa fa-dollar"></i><span><%= data.items[p].price %></span><small>起</small>
           </p>
@@ -80,6 +80,10 @@
               <button  style="margin: 9px 8px 0 0;" class="btn btn-default col-xs-12 col-sm-12 col-md-12 col-lg-12 col-xl-12" disabled>訂購</button>
             <% } %>
           </div>
+          <!-- display a space between products in mobile size -->
+          <% if(p !== len -1) { %>
+            <div class="hidden-lg hidden-md hidden-sm" style="height:40px"></div>
+          <% } %>
         </div>
       <% } %>
     <% } %>


### PR DESCRIPTION
1. 註解掉商品與資訊間的隱藏「限量優惠」block
2. 在mobile中，在商品之間增加空白空間，加大商品間距
#1728 