### PR TITLE
訂單資料 欄位名稱&順序優化 PR

### DIFF
--- a/views-b2b/admin/order/form.ejs
+++ b/views-b2b/admin/order/form.ejs
@@ -313,19 +313,19 @@
 <script>
 var formRules = {}
 const requiredFieldName =[
-  "firstname", 
-  "lastname", 
-  "email",
-  "telephone", 
-  "fax",
-  "shippingFirstname",
-  "shippingLastname", 
-  "shippingAddress1", 
-  "shippingCity", 
-  "shippingPostcode",
-  "shippingMethod", 
-  "total", 
-  "tracking"
+  'firstname', 
+  'lastname', 
+  'email',
+  'telephone', 
+  'fax',
+  'shippingFirstname',
+  'shippingLastname', 
+  'shippingAddress1', 
+  'shippingCity', 
+  'shippingPostcode',
+  'shippingMethod', 
+  'total', 
+  'tracking'
 ]
 requiredFieldName.forEach((field) => formRules[field] = {required:true})
 formRules.email.email = true
@@ -333,43 +333,43 @@ formRules.email.email = true
 // Messages for form validation
 var formMessages = {
   firstname: {
-    required: "請給予名字"
+    required: '請給予名字'
   },
   lastname: {
-    required: "請給予姓氏"
+    required: '請給予姓氏'
   },
   email: {
-    required: "請給予電子郵件"
+    required: '請給予電子郵件'
   },
   telephone: {
-    required: "請給予電話"
+    required: '請給予電話'
   },
   fax: {
-    required: "請給予傳真號碼"
+    required: '請給予傳真號碼'
   },
   shippingFirstname: {
-    required: "請給予運送名字"
+    required: '請給予運送名字'
   },
   shippingLastname: {
-    required: "請給予運送姓氏"
+    required: '請給予運送姓氏'
   },
   shippingAddress1: {
-    required: "請給予運送地址"
+    required: '請給予運送地址'
   },
   shippingCity: {
-    required: "請給予運送縣市"
+    required: '請給予運送縣市'
   },
   shippingPostcode: {
-    required: "請給予運送郵遞區號"
+    required: '請給予運送郵遞區號'
   },
   shippingMethod: {
-    required: "請給予運送方式"
+    required: '請給予運送方式'
   },
   total: {
-    required: "請給予總數"
+    required: '請給予總數'
   },
   tracking: {
-    required: "請給予追蹤代碼"
+    required: '請給予追蹤代碼'
   }
 }
 </script>

--- a/views-b2b/admin/order/form.ejs
+++ b/views-b2b/admin/order/form.ejs
@@ -311,48 +311,24 @@
 
 </fieldset>
 <script>
-var formRules = {
-  firstname: {
-    required: true
-  },
-  lastname: {
-    required: true
-  },
-  email: {
-    required: true,
-    email: true,
-  },
-  telephone: {
-    required: true
-  },
-  fax: {
-    required: true
-  },
-  shippingFirstname: {
-    required: true
-  },
-  shippingLastname: {
-    required: true
-  },
-  shippingAddress1: {
-    required: true
-  },
-  shippingCity: {
-    required: true
-  },
-  shippingPostcode: {
-    required: true
-  },
-  shippingMethod: {
-    required: true
-  },
-  total: {
-    required: true
-  },
-  tracking: {
-    required: true
-  }
-}
+var formRules = {}
+const requiredFieldName =[
+  "firstname", 
+  "lastname", 
+  "email",
+  "telephone", 
+  "fax",
+  "shippingFirstname",
+  "shippingLastname", 
+  "shippingAddress1", 
+  "shippingCity", 
+  "shippingPostcode",
+  "shippingMethod", 
+  "total", 
+  "tracking"
+]
+requiredFieldName.forEach((field) => formRules[field] = {required:true})
+formRules.email.email = true
 
 // Messages for form validation
 var formMessages = {

--- a/views-b2b/admin/order/form.ejs
+++ b/views-b2b/admin/order/form.ejs
@@ -7,23 +7,7 @@
         <input type="text" name="orderNumber" placeholder="" v-model="data.item.orderNumber" disabled>
         <b class="tooltip tooltip-bottom-right">訂單編號</b></label>
     </section>
-
-    <section class="col col-lg-4 col-xs-4">
-      <label class="label">訂購名字</label>
-      <label class="input state-disabled">
-        <input type="text" name="firstname" placeholder="" v-model="data.item.firstname" disabled>
-        <b class="tooltip tooltip-bottom-right">名字</b></label>
-    </section>
-
-    <section class="col col-lg-4 col-xs-4">
-      <label class="label">訂購姓氏</label>
-      <label class="input state-disabled">
-        <input type="text" name="lastname" placeholder="" v-model="data.item.lastname" disabled>
-        <b class="tooltip tooltip-bottom-right">姓氏</b></label>
-    </section>
-  </div>
-
-  <div class="row">
+    
     <section class="col col-lg-4 col-xs-4">
       <label class="label">發票開頭</label>
       <label class="input state-disabled">
@@ -63,41 +47,58 @@
   </div>
 
   <div class="row">
+
     <section class="col col-lg-4 col-xs-4">
-      <label class="label">電子郵件</label>
+      <label class="label">訂購人 姓氏</label>
+      <label class="input state-disabled">
+        <input type="text" name="lastname" placeholder="" v-model="data.item.lastname" disabled>
+        <b class="tooltip tooltip-bottom-right">訂購人姓氏</b></label>
+    </section>
+
+    <section class="col col-lg-4 col-xs-4">
+      <label class="label">訂購人 名字</label>
+      <label class="input state-disabled">
+        <input type="text" name="firstname" placeholder="" v-model="data.item.firstname" disabled>
+        <b class="tooltip tooltip-bottom-right">訂購人名字</b></label>
+    </section>
+  </div>
+
+  <div class="row">
+    <section class="col col-lg-4 col-xs-4">
+      <label class="label">訂購人 電子郵件</label>
       <label class="input state-disabled">
         <input type="text" name="email" placeholder="" v-model="data.item.email" disabled>
-        <b class="tooltip tooltip-bottom-right">電子郵件</b></label>
+        <b class="tooltip tooltip-bottom-right">訂購人電子郵件</b></label>
     </section>
 
     <section class="col col-lg-4 col-xs-4">
-      <label class="label">電話</label>
+      <label class="label">訂購人 聯絡電話</label>
       <label class="input state-disabled">
         <input type="text" name="telephone" placeholder="" v-model="data.item.telephone" disabled>
-        <b class="tooltip tooltip-bottom-right">電話</b></label>
+        <b class="tooltip tooltip-bottom-right">訂購人聯絡電話</b></label>
     </section>
 
     <section class="col col-lg-4 col-xs-4">
-      <label class="label">傳真</label>
+      <label class="label">訂購人 傳真號碼</label>
       <label class="input state-disabled">
         <input type="text" name="fax" placeholder="" v-model="data.item.fax" disabled>
-        <b class="tooltip tooltip-bottom-right">傳真</b></label>
+        <b class="tooltip tooltip-bottom-right">訂購人傳真號碼</b></label>
     </section>
   </div>
 
   <div class="row hidden">
     <section class="col col-lg-3 col-xs-3">
-      <label class="label">付款名字</label>
+      <label class="label">付款人 名字</label>
       <label class="input state-disabled">
         <input type="text" name="paymentFirstname" placeholder="" v-model="data.item.paymentFirstname" disabled>
-        <b class="tooltip tooltip-bottom-right">付款名字</b></label>
+        <b class="tooltip tooltip-bottom-right">付款人名字</b></label>
     </section>
 
     <section class="col col-lg-3 col-xs-3">
-      <label class="label">付款姓氏</label>
+      <label class="label">付款人 姓氏</label>
       <label class="input state-disabled">
         <input type="text" name="paymentLastname" placeholder="" v-model="data.item.paymentLastname" disabled>
-        <b class="tooltip tooltip-bottom-right">付款姓氏</b></label>
+        <b class="tooltip tooltip-bottom-right">付款人姓氏</b></label>
     </section>
 
     <section class="col col-lg-3 col-xs-3">
@@ -141,19 +142,58 @@
 
   <div class="row">
     <section class="col col-lg-3 col-xs-3">
-      <label class="label">運送名字</label>
+      <label class="label">收件者 姓氏</label>
+      <label class="input state-disabled">
+        <input type="text" name="shippingLastname" placeholder="" v-model="data.item.shippingLastname" disabled>
+        <b class="tooltip tooltip-bottom-right">收件者姓氏</b></label>
+    </section>
+    
+    <section class="col col-lg-3 col-xs-3">
+      <label class="label">收件者 名字</label>
       <label class="input state-disabled">
         <input type="text" name="shippingFirstname" placeholder="" v-model="data.item.shippingFirstname" disabled>
-        <b class="tooltip tooltip-bottom-right">運送名字</b></label>
+        <b class="tooltip tooltip-bottom-right">收件者名字</b></label>
+    </section>
+    
+    <section class="col col-lg-3 col-xs-3">
+      <label class="label">收件者 電話</label>
+      <label class="input state-disabled">
+        <input type="text" name="shippingTelephone" placeholder="" v-model="data.item.shippingTelephone" disabled>
+        <b class="tooltip tooltip-bottom-right">收件者電話</b></label>
     </section>
 
     <section class="col col-lg-3 col-xs-3">
-      <label class="label">運送姓氏</label>
+      <label class="label">收件者 郵件</label>
       <label class="input state-disabled">
-        <input type="text" name="shippingLastname" placeholder="" v-model="data.item.shippingLastname" disabled>
-        <b class="tooltip tooltip-bottom-right">運送姓氏</b></label>
+        <input type="text" name="shippingEmail" placeholder="" v-model="data.item.shippingEmail" disabled>
+        <b class="tooltip tooltip-bottom-right">收件者郵件</b></label>
+    </section>
+  </div>
+
+  <div class="row">
+    <section class="col col-lg-3 col-xs-3">
+      <label class="label">收件者 郵遞區號</label>
+      <label class="input state-disabled">
+        <input type="text" name="shippingPostcode" placeholder="" v-model="data.item.shippingPostcode" disabled>
+        <b class="tooltip tooltip-bottom-right">收件者郵遞區號</b></label>
     </section>
 
+    <section class="col col-lg-3 col-xs-3">
+      <label class="label">收件者 所在城市</label>
+      <label class="input state-disabled">
+        <input type="text" name="shippingCity" placeholder="" v-model="data.item.shippingCity" disabled>
+        <b class="tooltip tooltip-bottom-right">收件者所在城市</b></label>
+    </section>
+
+    <section class="col col-lg-6 col-xs-6">
+      <label class="label">收件者 地址</label>
+      <label class="input state-disabled">
+        <input type="text" name="shippingAddress1" placeholder="" v-model="data.item.shippingAddress1" disabled>
+        <b class="tooltip tooltip-bottom-right">收件者地址</b></label>
+    </section>
+  </div>
+
+  <div class="row">
     <section class="col col-lg-3 col-xs-3">
       <label class="label">運送方式</label>
       <label class="input state-disabled">
@@ -167,46 +207,6 @@
         <input type="text" name="shippingCode" placeholder="" v-model="data.item.shippingCode" disabled>
         <b class="tooltip tooltip-bottom-right">運送代碼</b></label>
     </section>
-  </div>
-
-  <div class="row">
-    <section class="col col-lg-3 col-xs-3">
-      <label class="label">運送電話</label>
-      <label class="input state-disabled">
-        <input type="text" name="shippingTelephone" placeholder="" v-model="data.item.shippingTelephone" disabled>
-        <b class="tooltip tooltip-bottom-right">運送電話</b></label>
-    </section>
-
-    <section class="col col-lg-3 col-xs-3">
-      <label class="label">運送郵件</label>
-      <label class="input state-disabled">
-        <input type="text" name="shippingEmail" placeholder="" v-model="data.item.shippingEmail" disabled>
-        <b class="tooltip tooltip-bottom-right">運送郵件</b></label>
-    </section>
-  </div>
-
-  <div class="row">
-    <section class="col col-lg-3 col-xs-3">
-      <label class="label">運送郵遞區號</label>
-      <label class="input state-disabled">
-        <input type="text" name="shippingPostcode" placeholder="" v-model="data.item.shippingPostcode" disabled>
-        <b class="tooltip tooltip-bottom-right">運送郵遞區號</b></label>
-    </section>
-
-    <section class="col col-lg-3 col-xs-3">
-      <label class="label">運送城市</label>
-      <label class="input state-disabled">
-        <input type="text" name="shippingCity" placeholder="" v-model="data.item.shippingCity" disabled>
-        <b class="tooltip tooltip-bottom-right">運送城市</b></label>
-    </section>
-
-    <section class="col col-lg-6 col-xs-6">
-      <label class="label">運送地址</label>
-      <label class="input state-disabled">
-        <input type="text" name="shippingAddress1" placeholder="" v-model="data.item.shippingAddress1" disabled>
-        <b class="tooltip tooltip-bottom-right">運送地址</b></label>
-    </section>
-
   </div>
 
   <div class="row">
@@ -263,8 +263,8 @@
             <tr>
               <th>產品名稱</th>
               <th>供應商</th>
-              <th>數量</th>
               <th>價格</th>
+              <th>數量</th>
               <th>合計</th>
             </tr>
           </thead>
@@ -274,8 +274,8 @@
               <td class="col-xs-3">
                 {{ orderProduct.supplierName }}
               </td>
-              <td class="col-xs-2">{{ orderProduct.quantity }}</td>
               <td class="col-xs-2">{{ orderProduct.formatPrice }}</td>
+              <td class="col-xs-2">{{ orderProduct.quantity }}</td>
               <td class="col-xs-2">{{ orderProduct.formatTotal }}</td>
             </tr>
           </tbody>
@@ -312,12 +312,6 @@
 </fieldset>
 <script>
 var formRules = {
-  // invoiceNo: {
-  //   required: true
-  // },
-  // invoicePrefix: {
-  //   required: true
-  // },
   firstname: {
     required: true
   },
@@ -334,27 +328,6 @@ var formRules = {
   fax: {
     required: true
   },
-  // paymentFirstname: {
-  //   required: true
-  // },
-  // paymentLastname: {
-  //   required: true
-  // },
-  // paymentAddress1: {
-  //   required: true
-  // },
-  // paymentCity: {
-  //   required: true
-  // },
-  // paymentPostcode: {
-  //   required: true
-  // },
-  // paymentMethod: {
-  //   required: true
-  // },
-  // paymentCode: {
-  //   required: true
-  // },
   shippingFirstname: {
     required: true
   },
@@ -373,37 +346,16 @@ var formRules = {
   shippingMethod: {
     required: true
   },
-  // shippingCode: {
-  //   required: true
-  // },
-  // comment: {
-  //   required: true
-  // },
   total: {
     required: true
   },
   tracking: {
     required: true
-  },
-  // AllpayId: {
-  //   required: true,
-  //   digits: true
-  // },
-  // UserId: {
-  //   required: true,
-  //   digits: true
-  // }
+  }
 }
 
 // Messages for form validation
 var formMessages = {
-
-  // invoiceNo: {
-  //   required: "請給予發票號碼"
-  // },
-  // invoicePrefix: {
-  //   required: "請給予發票開頭"
-  // },
   firstname: {
     required: "請給予名字"
   },
@@ -419,27 +371,6 @@ var formMessages = {
   fax: {
     required: "請給予傳真號碼"
   },
-  // paymentFirstname: {
-  //   required: "請給予付款名字"
-  // },
-  // paymentLastname: {
-  //   required: "請給予付款姓氏"
-  // },
-  // paymentAddress1: {
-  //   required: "請給予付款地址"
-  // },
-  // paymentCity: {
-  //   required: "請給予付款縣市"
-  // },
-  // paymentPostcode: {
-  //   required: "請給予付款郵遞區號"
-  // },
-  // paymentMethod: {
-  //   required: "請給予付款方式"
-  // },
-  // paymentCode: {
-  //   required: "請給予付款代碼"
-  // },
   shippingFirstname: {
     required: "請給予運送名字"
   },
@@ -458,26 +389,11 @@ var formMessages = {
   shippingMethod: {
     required: "請給予運送方式"
   },
-  // shippingCode: {
-  //   required: "請給予運送代碼"
-  // },
-  // comment: {
-  //   required: "請給予附註"
-  // },
   total: {
     required: "請給予總數"
   },
   tracking: {
     required: "請給予追蹤代碼"
-  },
-
-  // AllpayId: {
-  //   required: "請給予支付ID",
-  //   digits: "請輸入整數"
-  // },
-  // UserId: {
-  //   required: "請給予會員ID",
-  //   digits: "請輸入整數"
-  // },
+  }
 }
 </script>


### PR DESCRIPTION
- 順便調整一下順序 
分類成四個部分
比較方便閱讀
  1. 訂單基本資訊
  2. 訂購人資訊
  3. 收件者資訊
  4. 運送資訊

- 順便將下方的formRules簡化了一下
- 將雙引號改為雙引號

#1747 